### PR TITLE
Add g2-microphone permission so voice reply works

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,6 +12,10 @@
       "whitelist": [
         "*"
       ]
+    },
+    {
+      "desc": "Captures audio from the glasses microphone so you can dictate voice replies, which are transcribed and sent as messages.",
+      "name": "g2-microphone"
     }
   ],
   "supported_languages": [


### PR DESCRIPTION
## Summary

Voice reply on the glasses calls `bridge.audioControl(true)` at `src/glasses/GlassesUI.tsx:1497`, but the `g2-microphone` permission is missing from `app.json`. EvenHub rejects the mic-open call, the catch branch fires, and the glasses display `VOICE_MIC_UNAVAILABLE_STATUS` ("Not Allowed") — voice reply is broken on shipped builds.

Adding the `g2-microphone` permission entry lets EvenHub grant the mic, after which the existing audio capture and Whisper transcription flow works end-to-end. One-line, manifest-only change — no behavior changes outside the now-enabled voice path.

## Test plan

- [x] Verified locally on G2 glasses via `evenhub qr` against the Vite dev server: mic opens (no more "Not Allowed"), transcript appears, message sends through Beeper.
- [x] `npm run build` succeeds.
- [ ] Maintainer-side smoke check on a fresh Even Realities phone-app install.

## Reference

Even Hub SDK permission name confirmed against the official Even Realities skill suite (`build-and-deploy` and `cli-reference` skills) — valid permissions are `network`, `location`, `g2-microphone`, `phone-microphone`, `album`, `camera`.